### PR TITLE
PLEASE REVIEW - Dt47 navigation link select also expands subfolders

### DIFF
--- a/src/main/groovy/com/alliancels/documentation/HtmlPresenter.groovy
+++ b/src/main/groovy/com/alliancels/documentation/HtmlPresenter.groovy
@@ -132,7 +132,7 @@ class HtmlPresenter {
             //Create an event listener for each link, if link is clicked, run function below
             for (var i = 0; i < listOfLinks.length; i++) 
             {
-                listOfLinks[i].addEventListener("click", linkClickExpandsDetails(i));
+                listOfLinks[i].addEventListener("dblclick", linkClickExpandsDetails(i));
             };
             
             //Expand details if collapsed/collapse details if expanded

--- a/src/main/groovy/com/alliancels/documentation/HtmlPresenter.groovy
+++ b/src/main/groovy/com/alliancels/documentation/HtmlPresenter.groovy
@@ -121,6 +121,39 @@ class HtmlPresenter {
                 <iframe name="sectionFrame"></iframe>
             </div>
         </div>
+
+        //JS for selecting hyperlink in navigation pane expands/collapses the subfolders to that hyperlink
+        <script type="text/javascript">
+
+            //Get list of link elements and details
+            var listOfLinks = document.getElementsByTagName('a');
+            var listOfDetails = document.querySelectorAll('details');
+            
+            //Create an event listener for each link, if link is clicked, run function below
+            for (var i = 0; i < listOfLinks.length; i++) 
+            {
+                listOfLinks[i].addEventListener("click", linkClickExpandsDetails(i));
+            };
+            
+            //Expand details if collapsed/collapse details if expanded
+            function linkClickExpandsDetails(i)
+            {   
+                return function()
+                {
+                    //Must be i-1 because there is 1 more link than there are details due to the "EXPAND/COLLAPSE ALL" link at the top
+                    if(listOfDetails[i-1].open)
+                    {
+                        listOfDetails[i-1].open = false;
+                    }
+                    else
+                    {
+                        listOfDetails[i-1].open = true;
+                    }
+                };
+            };
+            
+        </script>
+
     </html>
     """
     }


### PR DESCRIPTION
Issue: https://alliancels.myjetbrains.com/youtrack/issue/DT-47

This is first (very simple) part of changes to documentation tools. 

In order to test this on the documentation-gradle-plugins example project:
-Checkout this branch
-In cmd.exe go to _WorkingDirectory_/documentation-gradle-plugins/example
-Run "gradlew --include-build .. aA" command
-Check to see that when you double click a link in the navigation pane it expands/collapses said link

In order to test this on Midas/Titan documentation:
-Go to gradle.build file for Midas/Titan documentation
-Change the maven-repo path from release to test_DT47_DoubleClickToNavigate
![image](https://user-images.githubusercontent.com/11274137/62139561-3170ae80-b2af-11e9-8df0-aa6b78b7c3a0.png)
-In cmd.exe go to _WorkingDirectory_/Titan
-Run "gradlew --refresh-dependencies" command
-Run "gradlew Docs:aA" command
-Check to see that when you double click a link in the navigation pane it expands/collapses said link

Let me know if you have any questions


