### PR TITLE
Fix bug where checking for broken links always failed due to

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ documentation {
 ### Build Documentation
 
 For each `Document` object defined in the build script, a task called `build<document name>' will be created.
-This simply chains the "assemble" and "check" tasks into a single command.
+This simply chains the "assemble", "check", and "combine" tasks into a single command.
 
 # Build
 

--- a/src/main/groovy/com/alliancels/documentation/CombineDocsTask.groovy
+++ b/src/main/groovy/com/alliancels/documentation/CombineDocsTask.groovy
@@ -30,10 +30,10 @@ class CombineDocsTask extends SourceTask {
             sections.add((new LayoutParser()).createSection(it))
         }
         
-        println("Updating glossary terms and links...")
+        //Updating glossary terms and links
         GlossaryAutoLink.autoLinkGlossary(sections, project.buildDir, project.projectDir)
         
-        println("Generating combined docs...")
+        //Generate combined docs
         createCombinedDocs()
     }
 
@@ -55,18 +55,16 @@ class CombineDocsTask extends SourceTask {
 
     void createCombinedDocs() {
 
-        //Create empty file for all in one combined doc
+        //Create all in one combined doc
         File docBeingGenerated = new File("${project.buildDir}/documentation/All/AllDocsCombined.html")
         docBeingGenerated.createNewFile()
         docBeingGenerated.text = ''
-        println("Generated combined doc/page for: AllDocsCombined")
         
-        //Create a combined doc page for each folder in source directory
+        //Create a combined doc for each folder in source directory
         documentSourceDirs.each {
             File individualDocBeingGenerated = new File("${project.buildDir}/documentation/All/${it}.html")
             individualDocBeingGenerated.createNewFile()
             individualDocBeingGenerated.text = ''
-            println("Generated combined doc/page for: $it")
         
             //The order of how each page is added to the combined page matches the order followed in navigation
             //Add page individual document as well as all combined document
@@ -92,8 +90,6 @@ class CombineDocsTask extends SourceTask {
         //Add combined link to navigation page 
         String addCombinedDocToNav = "AllDocsCombined"
         addCombinedLinksToNavigation(addCombinedDocToNav)
-        
-        println("Docs generated!")
     }
 	
 	void navigateDocDirectoryToBuildCombinedPage(Section section, File file) {

--- a/src/main/groovy/com/alliancels/documentation/DocumentationPlugin.groovy
+++ b/src/main/groovy/com/alliancels/documentation/DocumentationPlugin.groovy
@@ -26,7 +26,7 @@ class DocumentationPlugin implements Plugin<Project> {
             // Create a task to convert all markdown files
             project.task('markdownToHtml', type: MarkdownToHtmlTask) {
                 description = "Convert all markdown files to html files"
-                outputs.upToDateWhen {convertedMarkdown.exists()}
+                outputs.upToDateWhen {false}
                 include "**/*.md"
                 outputDir = convertedMarkdown
                 source getAllSourceFolders(extension.documents)
@@ -50,7 +50,7 @@ class DocumentationPlugin implements Plugin<Project> {
 
         project.task("copyImages${document.name}", type: FileCopyTask) {
             description = "Copy images into the output for the ${document.name} document."
-            outputs.upToDateWhen {outputFolder.exists()}
+            outputs.upToDateWhen {false}
             include "**/Images/**"
             outputDir = outputFolder
             source document.sourceFolders
@@ -58,7 +58,7 @@ class DocumentationPlugin implements Plugin<Project> {
 
         project.task("navigation${document.name}", type: NavigationHtmlTask) {
             description = "Create navigation page and navigation links for the ${document.name} document."
-            outputs.upToDateWhen {links.exists()}
+            outputs.upToDateWhen {false}
             include "**/layout.yaml"
             linkOutputDir = links
             navigationOutputDir = outputFolder
@@ -82,6 +82,7 @@ class DocumentationPlugin implements Plugin<Project> {
         
         project.task("combine${document.name}", type: CombineDocsTask) {
             description = "Create combined pages for the ${document.name} document."
+            outputs.upToDateWhen {false}
             include "**/layout.yaml"
             documentSourceDirs = document.sourceFolders
             source document.sourceFolders
@@ -89,6 +90,7 @@ class DocumentationPlugin implements Plugin<Project> {
 
         project.task("check${document.name}", type: CheckDocumentTask) {
             description = "Check the ${document.name} document for problems."
+            outputs.upToDateWhen {false}
             source outputFolder
             document.sourceFolders.each {
                 include "${it}/**/*.html"

--- a/src/main/groovy/com/alliancels/documentation/DocumentationPlugin.groovy
+++ b/src/main/groovy/com/alliancels/documentation/DocumentationPlugin.groovy
@@ -26,6 +26,7 @@ class DocumentationPlugin implements Plugin<Project> {
             // Create a task to convert all markdown files
             project.task('markdownToHtml', type: MarkdownToHtmlTask) {
                 description = "Convert all markdown files to html files"
+                outputs.upToDateWhen {convertedMarkdown.exists()}
                 include "**/*.md"
                 outputDir = convertedMarkdown
                 source getAllSourceFolders(extension.documents)
@@ -49,6 +50,7 @@ class DocumentationPlugin implements Plugin<Project> {
 
         project.task("copyImages${document.name}", type: FileCopyTask) {
             description = "Copy images into the output for the ${document.name} document."
+            outputs.upToDateWhen {outputFolder.exists()}
             include "**/Images/**"
             outputDir = outputFolder
             source document.sourceFolders
@@ -56,6 +58,7 @@ class DocumentationPlugin implements Plugin<Project> {
 
         project.task("navigation${document.name}", type: NavigationHtmlTask) {
             description = "Create navigation page and navigation links for the ${document.name} document."
+            outputs.upToDateWhen {links.exists()}
             include "**/layout.yaml"
             linkOutputDir = links
             navigationOutputDir = outputFolder
@@ -66,6 +69,7 @@ class DocumentationPlugin implements Plugin<Project> {
         project.task("assemble${document.name}", type: AssembleDocumentTask,
                 dependsOn: ['markdownToHtml', "copyImages${document.name}", "navigation${document.name}"]) {
             description = "Assemble the ${document.name} document."
+            outputs.upToDateWhen {false}
             outputDir = outputFolder
             linkDir = links
             convertedMarkdownDir = convertedMarkdown
@@ -91,7 +95,7 @@ class DocumentationPlugin implements Plugin<Project> {
             }
         }
 
-        project.task("build${document.name}", dependsOn:["assemble${document.name}", "check${document.name}"]) {
+        project.task("build${document.name}", dependsOn:["assemble${document.name}", "check${document.name}", "combine${document.name}"]) {
             description = "Build the ${document.name} document, by assembling it and checking it for problems."
         }
     }

--- a/src/main/groovy/com/alliancels/documentation/GlossaryAutoLink.groovy
+++ b/src/main/groovy/com/alliancels/documentation/GlossaryAutoLink.groovy
@@ -48,11 +48,6 @@ class GlossaryAutoLink {
             }
         }
         
-        if(glossarySectionList.size() > 0)
-        {
-            println("Number of glossaries found: " + glossarySectionList.size())
-        }
-        
         return glossarySectionList
     }
     
@@ -157,8 +152,6 @@ class GlossaryAutoLink {
 
             htmlFile.text = htmlFileText
         }
-        
-        println("Terms and links updated!")
     }
     
     static File getBuildFileFromSourceFile(File sourceFile, File sourceDirectory, File buildDirectory) {

--- a/src/main/groovy/com/alliancels/documentation/NavigationHtmlTask.groovy
+++ b/src/main/groovy/com/alliancels/documentation/NavigationHtmlTask.groovy
@@ -66,8 +66,8 @@ class NavigationHtmlTask extends SourceTask {
                 File previousLinkFile = getLinkOutputFile(previousGroup.folder)
                 File nextLinkFile = getLinkOutputFile(nextGroup.folder)
                 
-                previousLink += "\\" + previousLinkFile.getName()
-                nextLink += "\\" + nextLinkFile.getName()
+                previousLink += "/" + previousLinkFile.getName()
+                nextLink += "/" + nextLinkFile.getName()
                 
                 navigationLinkHtml = HtmlPresenter.getPreviousNextLinks(previousLink, nextLink)
             } else if (previousGroup == null && nextGroup != null) {
@@ -75,7 +75,7 @@ class NavigationHtmlTask extends SourceTask {
                 
                 File nextLinkFile = getLinkOutputFile(nextGroup.folder)
                 
-                nextLink += "\\" + nextLinkFile.getName()
+                nextLink += "/" + nextLinkFile.getName()
                 
                 navigationLinkHtml = HtmlPresenter.getNextLink(nextLink)
             } else if (previousGroup != null && nextGroup == null) {
@@ -83,7 +83,7 @@ class NavigationHtmlTask extends SourceTask {
                 
                 File previousLinkFile = getLinkOutputFile(previousGroup.folder)
                 
-                previousLink += "\\" + previousLinkFile.getName()
+                previousLink += "/" + previousLinkFile.getName()
                 
                 navigationLinkHtml = HtmlPresenter.getPreviousLink(previousLink)
             } else {


### PR DESCRIPTION
changes in "next"/"previous" link generation mistakenly adding escaped
back slash rather than, correctly, forward slash.

This bug was previously introduced when code was modified to allow
unique .md file names instead of enforcing "section.md" file name.

Issue:
https://alliancels.myjetbrains.com/youtrack/issue/DT-51

External project test branch on maven repo for doc tools changes:
https://github.com/alliancels/maven-repo/tree/DT51_ExternalTestBranch

Titan branch with fixed links and gradle build file set to use above external project test branch:
https://github.com/alliancels/Titan/tree/TIT770_FixMissedDocToolsBrokenLinks
(I'll create a separate pull request to review these documentation changes)
